### PR TITLE
fix: updated pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "backend"
+name = "app"
 version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]


### PR DESCRIPTION
ensures running `poetry install` works when others clone repo moving forward
name was incorrect