### PR TITLE
chore: setup local clickhouse

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,12 @@
+# Use the official ClickHouse image as a base
+FROM clickhouse/clickhouse-server:latest
+
+# Copy the initialization script and docker config into the container
+COPY init-db.sql /docker-entrypoint-initdb.d/
+# COPY custom-config.xml /etc/clickhouse-server/config.d/
+
+# Expose the ClickHouse ports
+# default ports already used by tests/ CH docker instance
+# note that couldnt get non-default ports working so went back to using 8123 and 9000, there may be conflicts with the tests/ instance
+EXPOSE 8123 9000
+

--- a/database/custom-config.xml
+++ b/database/custom-config.xml
@@ -1,0 +1,5 @@
+<!-- need this if changing default ports for clickhouse-server -->
+<yandex>
+    <http_port>8124</http_port>
+    <tcp_port>9001</tcp_port>
+</yandex>

--- a/database/init-db.sql
+++ b/database/init-db.sql
@@ -1,0 +1,14 @@
+CREATE DATABASE IF NOT EXISTS my_database;
+
+CREATE TABLE my_database.events
+(
+    user_id Int32,
+    session_id UUID,
+    event_type String,
+    event_timestamp DateTime,
+    page_url String,
+    product_id Int32
+) 
+ENGINE = MergeTree()
+ORDER BY (user_id, event_timestamp);
+

--- a/database/scripts/build-image.sh
+++ b/database/scripts/build-image.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+username="gcochran"
+
+sh ./scripts/kill-docker.sh
+docker build -t my-clickhouse-image .
+docker login
+docker tag my-clickhouse-image ${username}/my-clickhouse-image:dev
+docker push ${username}/my-clickhouse-image:dev

--- a/database/scripts/clickhouse-setup.sh
+++ b/database/scripts/clickhouse-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+username="gcochran"
+
+# Pull the Docker image
+docker pull ${username}/my-clickhouse-image:dev
+
+# Run the Docker container
+docker run -d --name my-clickhouse-container -p 8123:8123 -p 9000:9000 ${username}/my-clickhouse-image:dev
+
+# Wait a few seconds for the container to start up
+sleep 5
+
+# Execute the SQL command
+docker exec -i my-clickhouse-container clickhouse-client <<EOF
+INSERT INTO my_database.events (user_id, session_id, event_type, event_timestamp, page_url, product_id) VALUES
+(12345, generateUUIDv4(), 'click', now(), 'https://example.com', 67890),
+(6789, generateUUIDv4(), 'view', now(), 'http://example.com/items', 87891),
+(12345, generateUUIDv4(), 'purchase', now(), 'https://example.com', 73489),
+(23452, generateUUIDv4(), 'click', now(), 'https://example.com', 30423),
+(13489, generateUUIDv4(), 'view', now(), 'https://example.com', 23789);
+EOF

--- a/database/scripts/kill-docker.sh
+++ b/database/scripts/kill-docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+username="gcochran"
+
+docker stop my-clickhouse-container
+docker rm my-clickhouse-container
+docker rmi ${username}/my-clickhouse-image:dev


### PR DESCRIPTION
## Overview

created docker image for a clickhouse database

## Notes for reviewers
while in backend/databases run `sh scripts/clickhouse-setup.sh`

2 things we couldnt figure out:
1. how to expose ports different than the default clickhouse ports of 8123 and 9000. we tried a couple options and was just taking too much time 

3. how to easily insert data before pushing image to docker hub. we couldn't get the INSERT command to work in our `init-db.sql`. Rather we only created a database and table for the image, and the `clickhouse-setup.sh` script inserts some sample event data