### PR TITLE
fix: change poetry run_dev script to work with scripts.py function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.scripts]
 start-db = "scripts:start_db"
 build-image = "scripts:build_image"
-dev = "python3 app/main.py"
+dev = "scripts:run_dev"
 
 [tool.poetry.dependencies]
 python = "^3.12"

--- a/scripts.py
+++ b/scripts.py
@@ -10,3 +10,7 @@ def start_db():
 def build_image():
     result = subprocess.run(["sh", "database/scripts/build-image.sh"], check=True)
     sys.exit(result.returncode)
+
+def run_dev():
+    result = subprocess.run(["python3", "app/main.py"], check=True)
+    sys.exit(result.returncode)


### PR DESCRIPTION
## Overview
Added run_dev() function within scripts.py  and modified pyproject.toml with correct syntax for poetry script

## Changes
- pyproject.toml: dev = "scripts:run_dev"
- scripts.py: run_dev() function 

## Notes for Reviewers
- Nothing major to note