### PR TITLE
Chore/added generate data scripts

### DIFF
--- a/generate_data.py
+++ b/generate_data.py
@@ -1,0 +1,90 @@
+import json
+import random
+import time
+from datetime import datetime
+
+import boto3
+from faker import Faker
+
+fake = Faker()
+
+
+# Initialize the Kinesis client with the correct region
+
+root_session = boto3.Session(
+    aws_access_key_id="", aws_secret_access_key=""
+)  # Pass in credentials
+
+
+kinesis_client = root_session.client(
+    "kinesis", region_name="us-west-1"
+)  # Ensure this is the correct region
+
+
+import random
+from datetime import datetime, timezone
+
+fake = Faker()
+
+
+def generate_clickstream_data(user_id):
+    # Generate a timestamp based on the current time in UTC
+    event_timestamp = datetime.now(timezone.utc)
+
+    return {
+        "user_id": user_id,
+        "session_id": fake.uuid4(),
+        "event_type": random.choice(["click", "view", "purchase", "add_to_cart"]),
+        # "event_timestamp": event_timestamp.isoformat(),
+        "event_timestamp": event_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        "page_url": fake.url(),
+        "product_id": fake.random_int(min=1, max=100),
+    }
+
+
+def generate_purchase_history(user_id):
+    # Generate a timestamp based on the current time in UTC
+    purchase_timestamp = datetime.now(timezone.utc)
+
+    return {
+        "user_id": user_id,
+        "purchase_id": fake.random_int(min=1000, max=5000),
+        "product_id": fake.random_int(min=1, max=100),
+        "category": random.choice(["electronics", "books", "clothing", "home"]),
+        "purchase_timestamp": purchase_timestamp.isoformat(),
+        "amount": round(random.uniform(5.0, 500.0), 2),
+    }
+
+
+def send_to_kinesis(stream_name, data):
+    kinesis_client.put_record(
+        StreamName=stream_name, Data=json.dumps(data), PartitionKey=str(data["user_id"])
+    )
+
+
+def stream_data():
+    click_rate = 10  # clicks per second
+    purchase_rate = 1  # purchases per minute
+    purchase_interval = 60 / purchase_rate  # time interval between purchases
+    last_purchase_time = time.time()
+    count = 0
+
+    try:
+        # while True:
+        while count < 10:
+            current_time = time.time()
+            # Generate user ID
+            user_id = fake.random_int(min=1, max=1000)
+            # Generate clickstream data
+            clickstream_data = generate_clickstream_data(user_id)
+            send_to_kinesis("MyKinesisDataStream", clickstream_data)
+            print("Clickstream data:", json.dumps(clickstream_data))
+            time.sleep(1 / click_rate)
+            count += 1
+
+    except KeyboardInterrupt:
+        print("Script terminated by user.")
+
+
+if __name__ == "__main__":
+    stream_data()

--- a/generate_data.py
+++ b/generate_data.py
@@ -11,8 +11,12 @@ fake = Faker()
 
 # Initialize the Kinesis client with the correct region
 
+# root_session = boto3.Session(
+#     aws_access_key_id="", aws_secret_access_key=""
+# )  # Pass in credentials
 root_session = boto3.Session(
-    aws_access_key_id="", aws_secret_access_key=""
+    aws_access_key_id="",
+    aws_secret_access_key="",
 )  # Pass in credentials
 
 
@@ -29,14 +33,15 @@ fake = Faker()
 
 def generate_clickstream_data(user_id):
     # Generate a timestamp based on the current time in UTC
-    event_timestamp = datetime.now(timezone.utc)
+    # event_timestamp = datetime.now(timezone.utc)
 
     return {
         "user_id": user_id,
         "session_id": fake.uuid4(),
         "event_type": random.choice(["click", "view", "purchase", "add_to_cart"]),
         # "event_timestamp": event_timestamp.isoformat(),
-        "event_timestamp": event_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        # "event_timestamp": event_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        "event_timestamp": 1,
         "page_url": fake.url(),
         "product_id": fake.random_int(min=1, max=100),
     }

--- a/poetry.lock
+++ b/poetry.lock
@@ -56,6 +56,44 @@ files = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.34.143"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "boto3-1.34.143-py3-none-any.whl", hash = "sha256:0d16832f23e6bd3ae94e35ea8e625529850bfad9baccd426de96ad8f445d8e03"},
+    {file = "boto3-1.34.143.tar.gz", hash = "sha256:b590ce80c65149194def43ebf0ea1cf0533945502507837389a8d22e3ecbcf05"},
+]
+
+[package.dependencies]
+botocore = ">=1.34.143,<1.35.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.10.0,<0.11.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.34.143"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "botocore-1.34.143-py3-none-any.whl", hash = "sha256:094aea179e8aaa1bc957ad49cc27d93b189dd3a1f3075d8b0ca7c445a2a88430"},
+    {file = "botocore-1.34.143.tar.gz", hash = "sha256:059f032ec05733a836e04e869c5a15534420102f93116f3bc9a5b759b0651caf"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
+
+[package.extras]
+crt = ["awscrt (==0.20.11)"]
+
+[[package]]
 name = "certifi"
 version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -367,6 +405,20 @@ ssh = ["paramiko (>=2.4.3)"]
 websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
+name = "faker"
+version = "26.0.0"
+description = "Faker is a Python package that generates fake data for you."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Faker-26.0.0-py3-none-any.whl", hash = "sha256:886ee28219be96949cd21ecc96c4c742ee1680e77f687b095202c8def1a08f06"},
+    {file = "Faker-26.0.0.tar.gz", hash = "sha256:0f60978314973de02c00474c2ae899785a42b2cf4f41b7987e93c132a2b8a4a9"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.4"
+
+[[package]]
 name = "flake8"
 version = "7.1.0"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -481,6 +533,17 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
 
 [[package]]
 name = "lz4"
@@ -776,6 +839,20 @@ pluggy = ">=1.5,<2.0"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -843,6 +920,34 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.10.2"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "s3transfer-0.10.2-py3-none-any.whl", hash = "sha256:eca1c20de70a39daee580aef4986996620f365c4e0fda6a86100231d62f1bf69"},
+    {file = "s3transfer-0.10.2.tar.gz", hash = "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6"},
+]
+
+[package.dependencies]
+botocore = ">=1.33.2,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
 
 [[package]]
 name = "typing-extensions"
@@ -953,4 +1058,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e3dd150007c41cffc65af25e6f89cb33cedd036706898528798bc01bcb710b75"
+content-hash = "c039fe6d8504753ce5b6cdcfbeab349791dc36bbc8cb2da4b83d07b8555e0e8e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ start-db-mac = "scripts:start_db_mac"
 build-image = "scripts:build_image"
 build-image-mac = "scripts:build_image_mac"
 dev = "scripts:run_dev"
+generate = "scripts:generate_data"
 
 [tool.poetry.dependencies]
 python = "^3.12"
@@ -18,6 +19,8 @@ clickhouse-connect = "^0.7.16"
 python-dotenv = "^1.0.1"
 flask = "^3.0.3"
 flask-cors = "^4.0.1"
+boto3 = "^1.34.143"
+faker = "^26.0.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/scripts.py
+++ b/scripts.py
@@ -6,8 +6,11 @@ def start_db():
     result = subprocess.run(["sh", "database/scripts/clickhouse-setup.sh"], check=True)
     sys.exit(result.returncode)
 
+
 def start_db_mac():
-    result = subprocess.run(["sh", "database/scripts/clickhouse-setup-mac.sh"], check=True)
+    result = subprocess.run(
+        ["sh", "database/scripts/clickhouse-setup-mac.sh"], check=True
+    )
     sys.exit(result.returncode)
 
 
@@ -15,10 +18,18 @@ def build_image():
     result = subprocess.run(["sh", "database/scripts/build-image.sh"], check=True)
     sys.exit(result.returncode)
 
+
 def build_image_mac():
     result = subprocess.run(["sh", "database/scripts/build-image-mac.sh"], check=True)
     sys.exit(result.returncode)
 
+
 def run_dev():
     result = subprocess.run(["python3", "app/main.py"], check=True)
     sys.exit(result.returncode)
+
+
+def generate_data():
+    result = subprocess.run(["python3", "generate_data.py"], check=True)
+    sys.exit(result.returncode)
+


### PR DESCRIPTION
## Overview

A testing script to generate some fake streaming events using the faker library. Sends 10 events at a time to a Kinesis stream

## Changes

- event_timestamp is set to an integer as was unable to insert this data into clickhouse with it assigned to a datetime
  - clickstream interprets this integer as seconds since the first second of Jan 1, 1970
- only sends 10 events at a time but this piece of the code is easily altered if you adjust the while loop condition

## Notes for Reviewers
- update the AWS secret key locally in order to generate data
- `poetry run generate` will run this script