### PR TITLE
Fix/reset to client pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 poetry.lock
 __pycache__/
 *.ipynb
+dist

--- a/QueryRouteWithServerPagination.md
+++ b/QueryRouteWithServerPagination.md
@@ -1,0 +1,64 @@
+Chose to prioritize other features for now, might come back later
+
+# @api.route("/query", methods=["POST"])
+# def query():
+#     try:
+#         client = current_app.get_ch_client()
+#         print(f"in query route, client, from current_app.get_ch_client(), is: {client}")
+#         # request: { query__string: 'show tables;',  }
+#         # - Anything with a semicolon
+#         # request: { query_string 'show tables', page: null, pageSize: null}
+#         # - Shows page 1 of 0
+#         # request: { query_string 'select * from events', page: null, pageSize: null}
+#         # - Shows page 1 of 0
+
+#         # request: { query_string: 'select * from information_schema.COLUMNS limit 100'}
+#         # - Shows page 1 of 313
+#         # - Not paginating by 10
+
+#         # SELECT * FROM table LIMIT 100
+#         # - row_count = 10
+#         # - total_count = 100 (if table has 1000 rows total)
+
+        
+#         query_string, page, page_size, offset = destructure_query_request(request)
+#         print('abc1', query_string, page, page_size, offset)
+#         result = None
+#         if not page or not page_size:
+#           result = client.query(query_string)
+#         else:
+#           paginated_query = create_paginated_query(query_string, page_size, offset)
+#           result = client.query(paginated_query)
+            
+#         is_show_statement = query_string.strip().upper().startswith("SHOW")
+#         total_count = int(result.summary["read_rows"])
+#         if not is_show_statement:
+#             total_count_query = f"SELECT count(*) as total FROM ({query_string})"
+#             count_result = client.query(total_count_query)  # Assume this function exists
+#             total_count = int(count_result.result_rows[0][0])
+#         if not page_size:
+#             page_size = 10 
+            
+#         total_pages = ceil(total_count / page_size)
+#         #total_count_query = f"SELECT count(*) as total FROM ({query_string})"
+#         #total_count = client.query(total_count_query).first_row[0]
+#         print('abc3')
+
+#         data = [*result.named_results()]
+#         print('abc4', len(result.result_rows))
+#         response = {
+#             "metadata": {
+#                 "query": query_string,
+#                 "row_count": int(result.summary["read_rows"]),
+#                 "column_names": result.column_names,
+#                 "column_types": [t.base_type for t in result.column_types],
+#                 #"total_count": total_count,
+#                 "page": page,
+#                 "page_size": page_size,
+#                 "total_pages": total_pages
+#             },
+#             "data": data,
+#         }
+#         return jsonify(response)
+#     except Exception as e:
+#         return jsonify({"Query Route Error": str(e)}), 400

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -31,43 +31,6 @@ def create_paginated_query(query_string, page_size, offset):
     return paginated_query
 
 
-# kinesis-sample route 
-def connect_to_stream(client, kinesis_client, shard_iterator):
-    """
-    Trying for 10 seconds to grab a kinesis stream record using kinesis client
-    If event record exists, decode to JSON
-    Use event record and clickhouse client to infer schema
-    Return same event and inferrerd schema
-    """
-    seconds_to_try = 5
-    times_per_second = 3
-    count = 0
-    while count < times_per_second * seconds_to_try:
-        records = kinesis_client.get_records(
-          ShardIterator=shard_iterator,
-          Limit=1
-        )
-        print('Backend route Records: ', records)
-
-        if records['Records']:
-            record_data = records['Records'][0]['Data'].decode('utf-8')
-            
-            client.command("SET schema_inference_make_columns_nullable = 0;")
-            client.command("SET input_format_null_as_default = 0;")
-            res = client.query(f"DESC format(JSONEachRow, '{record_data}');")
-
-            schemaArray = []
-            for row in res.result_rows:
-                schema = {
-                    'name': row[0],
-                    'type': row[1]
-                }
-                schemaArray.append(schema)
-
-            return jsonify({"sampleEvent": json.loads(record_data), "inferredSchema": schemaArray})
-
-        count += 1
-        sleep(1/times_per_second)
 
 
 # create-table route
@@ -80,13 +43,6 @@ def destructure_create_table_request(request):
     schema = data["schema"]
     return stream_name, table_name, database_name, schema
 
-def validate_schema(schema):
-    if not isinstance(schema, list) or len(schema) == 0:
-        return jsonify({"Schema Error": "Invalid schema format"}), 400
-
-    for col in schema:
-        if not isinstance(col, dict) or "name" not in col or "type" not in col:
-            return jsonify({"Schema Error": "Invalid schema format"}), 400
 
 def get_stream_arn(global_boto3_session, stream_name):
     kinesis_client = global_boto3_session.client('kinesis')

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -21,9 +21,20 @@ def get_tables_in_db(client, db_name):
 # query route
 def destructure_query_request(request):
     query_string = request.json.get("query")
-    page = int(request.json.get("page", 1))
-    page_size = int(request.json.get("pageSize", 10))
-    offset = (page - 1) * page_size
+    print(f"request to destructure: {request.json}")
+    # page = request.json.get("page")
+    # Trying to get page parameter
+    # If page is None, keep it the same
+    # If page is not None ie '3', convert to int
+    page = request.json.get("page")
+    page_size = request.json.get('pageSize')
+    offset = None
+    print('abc2', page, page_size)
+    if page and page_size:
+        page = int(page)
+        page_size = int(page_size)
+        offset = (page - 1) * page_size
+    
     return query_string, page, page_size, offset
 
 def create_paginated_query(query_string, page_size, offset):


### PR DESCRIPTION
## Overview
- Due to numerous bugs in our server-side pagination, reverted to just using client-side pagination. 
- May reimplement server-side pagination at a later date based on needs of our users and bandwidth of team. 
- Note, SQL queries return quickly (sub-1 second) for tables with 100k rows or less with the client-side pagination setup.

## Changes
- Several helper methods were added back to `routes.py`.
- Elimination of server-side pagination code in `api/query` route
- `api/create-table` route: Trigger for the added Kinesis stream is added to the Lambda connector function 

## Notes for Reviewers
- To note - this PR accidentally also includes the Kinesis->Lambda trigger functionality. It's a small piece of code so we chose to just include in one workday PR rather than alter commits
