### PR TITLE
security: add is_sql_injection function for dangerous queries

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -17,6 +17,7 @@ from app.utils.helpers import (
     destructure_query_request, 
     destructure_create_table_request,
     get_stream_arn,
+    is_sql_injection,
     )
 
 api = Blueprint('main', __name__)
@@ -172,6 +173,9 @@ def create_table():
         
         query = create_table_query.strip()
         print('create table query: ', query)
+        if is_sql_injection(query, True):
+            return jsonify({"Error": "Possible dangerous query operation"})
+
         client.command(query)
 
         # TODO: Add Lambda Connection here to add a trigger for the Kinesis stream


### PR DESCRIPTION
## Overview
- Add is_sql_injection function to check for possibly dangerous operations within the create table route

## Changes
- Checks whether unexpected keywords or symbols like `--` and `DROP` are in the create table query, route throws error if check fails

## Notes for Reviewers
- Thinking about adding similar check for client.query() calls to Clickhouse