### PR TITLE
feat: backend logic for view sources page

### DIFF
--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -1,8 +1,9 @@
 import json
 import re
-from flask import jsonify
 from time import sleep
+
 from boto3.dynamodb.conditions import Key
+from flask import jsonify
 
 
 # get-databases route
@@ -74,7 +75,6 @@ def get_table_id(client, table_name):
 
 
 def get_table_info(client, table_id):
-    table_id = "55f071e3-d5b3-49f9-acbc-f43781d73904"  # TESTING
     res = client.query(
         f"""
         SELECT name, metadata_modification_time

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -4,18 +4,16 @@ from flask import jsonify
 from time import sleep
 from boto3.dynamodb.conditions import Key
 
+
 # get-databases route
 def get_db_names(client):
-    return [
-        db["name"] for db in client.query("SHOW DATABASES").named_results()
-    ]
+    return [db["name"] for db in client.query("SHOW DATABASES").named_results()]
+
 
 def get_tables_in_db(client, db_name):
     return [
         table["name"]
-        for table in client.query(
-            f"SHOW TABLES FROM {db_name}"
-        ).named_results()
+        for table in client.query(f"SHOW TABLES FROM {db_name}").named_results()
     ]
 
 
@@ -28,48 +26,82 @@ def destructure_query_request(request):
     # If page is None, keep it the same
     # If page is not None ie '3', convert to int
     page = request.json.get("page")
-    page_size = request.json.get('pageSize')
+    page_size = request.json.get("pageSize")
     offset = None
-    print('abc2', page, page_size)
+    print("abc2", page, page_size)
     if page and page_size:
         page = int(page)
         page_size = int(page_size)
         offset = (page - 1) * page_size
-    
+
     return query_string, page, page_size, offset
+
 
 def create_paginated_query(query_string, page_size, offset):
     paginated_query = f"{query_string} LIMIT {page_size} OFFSET {offset}"
     return paginated_query
 
 
-
-
 # create-table route
+
 
 def destructure_create_table_request(request):
     data = request.json
     stream_name = data["streamName"]
     table_name = data["tableName"]
-    database_name = data.get('databaseName', 'default')
+    database_name = data.get("databaseName", "default")
     schema = data["schema"]
     return stream_name, table_name, database_name, schema
 
 
 def get_stream_arn(global_boto3_session, stream_name):
-    kinesis_client = global_boto3_session.client('kinesis')
+    kinesis_client = global_boto3_session.client("kinesis")
     stream_description = kinesis_client.describe_stream(StreamName=stream_name)
-    stream_arn = stream_description['StreamDescription']['StreamARN']
+    stream_arn = stream_description["StreamDescription"]["StreamARN"]
     return stream_arn
 
+
 def get_table_id(client, table_name):
-    res = client.query(f"""
+    res = client.query(
+        f"""
         SELECT uuid
         FROM system.tables
         WHERE database = 'default'
         AND name = '{table_name}'
-        """)
+        """
+    )
     return res.first_row[0]
+
+
+def get_table_info(client, table_id):
+    table_id = "55f071e3-d5b3-49f9-acbc-f43781d73904"  # TESTING
+    res = client.query(
+        f"""
+        SELECT name, metadata_modification_time
+        FROM system.tables
+        WHERE database = 'default'
+        AND toString(uuid) = '{table_id}'
+        """
+    )
+    return res.first_row
+
+
+def parse_source_arn(stream_id):
+    stream_type = parse_source_arn_type(stream_id)
+    stream_name = parse_source_arn_name(stream_type, stream_id)
+    return stream_type, stream_name
+
+
+def parse_source_arn_type(stream_id):
+    return re.search(r"arn:aws:(\w+):", stream_id).group(1)
+
+
+def parse_source_arn_name(stream_type, stream_id):
+    if stream_type == "kinesis":
+        return stream_id.split("/")[-1]
+    elif stream_type == "s3":
+        return re.search(r":::(.+)", stream_id).group(0)
+
 
 def is_sql_injection(query, create_table=False):
     # List of dangerous SQL keywords
@@ -89,38 +121,31 @@ def is_sql_injection(query, create_table=False):
     if create_table:
         dangerous_keywords.append(";")
 
-    # Create a regex pattern
     pattern = (
         r"\b(" + "|".join(re.escape(keyword) for keyword in dangerous_keywords) + r")\b"
     )
 
-    # Check if any of the dangerous keywords are in the query
     if re.search(pattern, query, re.IGNORECASE):
         return True
     return False
 
+
 def add_table_stream_dynamodb(session, stream_arn, ch_table_id):
-    dynamo_client = session.resource('dynamodb')
-    dynamo_table = dynamo_client.Table('tables_streams')
+    dynamo_client = session.resource("dynamodb")
+    dynamo_table = dynamo_client.Table(
+        "streams_tables_map"
+    )  # TODO: dont hardcode this table name
 
     response = dynamo_table.query(
-        KeyConditionExpression=Key('stream_id').eq(stream_arn)
+        KeyConditionExpression=Key("stream_id").eq(stream_arn)
     )
-    
+
     # TODO: this delete if exists is not working
-    if len(response['Items']) == 1:
+    if len(response["Items"]) == 1:
         # If the item exists, delete it first
         dynamo_table.delete_item(
-            Key={
-                "stream_id": stream_arn,
-                "table_id": response['Items'][0]['table_id']
-            }
+            Key={"stream_id": stream_arn, "table_id": response["Items"][0]["table_id"]}
         )
         print(f"Existing entry for stream_id {stream_arn} deleted.")
 
-    dynamo_table.put_item(
-        Item={
-            "stream_id": stream_arn,
-            "table_id": str(ch_table_id)
-        }
-    )
+    dynamo_table.put_item(Item={"stream_id": stream_arn, "table_id": str(ch_table_id)})


### PR DESCRIPTION
## Overview
Added backend logic to handle requests for the frontend to list all existing data sources. New route: `/api/sources`

## Changes
Added several functions for the `/api/sources` route: `get_table_info`, `parse_source_arn`, `parse_source_arn_type`, `parse_source_arn_name`

## Notes for Reviewers
The helper functions are configured to currently work with both Amazon Kinesis and Amazon S3 ARNs.