### PR TITLE
feat: added routes for fetching OpenAI API key and viewing API output

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ def create_app(config=None, client=None):
     app.config["CH_PORT"] = int(os.getenv("CH_PORT", 8123))
     app.config["CH_USER"] = os.getenv("CH_USER", "default")
     app.config["CH_PASSWORD"] = os.getenv("CH_PASSWORD", "")
+    app.config["CHAT_GPT_API_KEY"] = os.getenv("CHAT_GPT_API_KEY", "")
 
     if config:
         logger.debug(f"Updating config: {config}")


### PR DESCRIPTION
## Overview
Added backend routes for fetching OpenAI API key and viewing API output.

## Changes
- Added `/api-key` and `/api-response` routes
- Created `fetch_openai_output` helper function
- Added "CHAT_GPT_API_KEY" environment variable to the app's configuration